### PR TITLE
Fix default user domain

### DIFF
--- a/setup_devstack_swift.sh
+++ b/setup_devstack_swift.sh
@@ -263,6 +263,8 @@ cache = swift.cache
 include_service_catalog = False
 delay_auth_decision = True
 auth_version = v3.0
+user_domain_id = default
+project_domain_id = default
 
 [filter:keystoneauth]
 use = egg:swift#keystoneauth


### PR DESCRIPTION
I couldn't auth so use the built environment because
authtoken configuration in the proxy was missing
at least the `user_domain_id = default`.
So added both:
  user_domain_id = default
  project_domain_id = default